### PR TITLE
circle: update Node versions

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,14 +1,16 @@
 dependencies:
   override:
-    - make setup
+    - printf '%s\n' color=false progress=false >.npmrc
+    - rm -rf node_modules
+    - case $CIRCLE_NODE_INDEX in 0) make setup ;; 1) nvm exec 4 make setup ;; 2) nvm install 6 && nvm exec 6 make setup ;; esac:
+        parallel: true
 
 machine:
   node:
-    version: 0.10.26
+    version: 0.12.7
 
 test:
   override:
-    - make test lint
-    - nvm use 0.12 && make test lint
-    - nvm use 4 && make test lint
-    - nvm use 5 && make test lint
+    - make lint
+    - case $CIRCLE_NODE_INDEX in 0) make test ;; 1) nvm exec 4 make test ;; 2) nvm exec 6 make test ;; esac:
+        parallel: true


### PR DESCRIPTION
Node v0.10 is no longer maintained, so we can remove it from the test matrix.
