### PR TITLE
sanctuary-def@0.15.x

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,28 @@
 {
   "root": true,
-  "extends": ["./node_modules/sanctuary-style/eslint-es3.json"],
-  "overrides": {
-    "files": ["*.md"],
-    "plugins": ["markdown"],
-    "rules": {
-      "no-undef": ["off"]
+  "extends": ["./node_modules/sanctuary-style/eslint-es6.json"],
+  "rules": {
+    "func-call-spacing": ["error", "always", {"allowNewlines": true}],
+    "no-extra-parens": ["off"]
+  },
+  "overrides": [
+    {
+      "files": ["*.md"],
+      "plugins": ["markdown"],
+      "rules": {
+        "no-undef": ["off"]
+      }
+    },
+    {
+      "files": ["index.js"],
+      "rules": {
+        "comma-dangle": ["error", "never"],
+        "func-style": ["error", "declaration", {"allowArrowFunctions": false}],
+        "indent": ["off"],
+        "no-unexpected-multiline": ["off"],
+        "no-var": ["off"],
+        "prefer-arrow-callback": ["off"]
+      }
     }
-  }
+  ]
 }

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "types"
   ],
   "dependencies": {
-    "sanctuary-def": "0.14.x"
+    "sanctuary-def": "0.15.x"
   },
   "ignore": [
     "/.circleci/",

--- a/index.js
+++ b/index.js
@@ -10,91 +10,97 @@
 
   /* istanbul ignore else */
   if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = f(require('sanctuary-def'));
+    module.exports = f (require ('sanctuary-def'));
   } else if (typeof define === 'function' && define.amd != null) {
-    define(['sanctuary-def'], f);
+    define (['sanctuary-def'], f);
   } else {
-    self.sanctuaryInt = f(self.sanctuaryDef);
+    self.sanctuaryInt = f (self.sanctuaryDef);
   }
 
-}(function($) {
+} (function($) {
 
   'use strict';
 
-  var int = {};
+  var _ = {};
 
   //  test :: Type -> Any -> Boolean
-  var test = $.test([]);
+  var test = $.test ([]);
 
   //# Int :: Type
   //.
   //. The Int type represents integers in the range [-2^31 .. 2^31).
-  var Int = $.NullaryType(
-    'sanctuary-int/Int',
-    'https://github.com/sanctuary-js/sanctuary-int#Int',
-    function(x) { return test($.Number, x) && (x | 0) === x; }
-  );
-  int.Int = Int;
+  var Int = $.NullaryType
+    ('sanctuary-int/Int')
+    ('https://github.com/sanctuary-js/sanctuary-int#Int')
+    (function(x) { return test ($.Number) (x) && (x | 0) === x; });
 
   //# NonZeroInt :: Type
   //.
   //. The NonZeroInt type represents non-zero integers in the range
   //. [-2^31 .. 2^31).
-  var NonZeroInt = $.NullaryType(
-    'sanctuary-int/NonZeroInt',
-    'https://github.com/sanctuary-js/sanctuary-int#NonZeroInt',
-    function(x) { return test(Int, x) && x !== 0; }
-  );
-  int.NonZeroInt = NonZeroInt;
-
-  //  env :: Array Type
-  var env = $.env.concat([Int, NonZeroInt]);
-
-  var def = $.create({checkTypes: true, env: env});
+  var NonZeroInt = $.NullaryType
+    ('sanctuary-int/NonZeroInt')
+    ('https://github.com/sanctuary-js/sanctuary-int#NonZeroInt')
+    (function(x) { return test (Int) (x) && x !== 0; });
 
   //# add :: Int -> Int -> Int
   //.
   //. Returns the sum of its two arguments.
   //.
   //. ```javascript
-  //. > add(1, 2)
+  //. > add (1) (2)
   //. 3
   //. ```
-  function add(m, n) {
-    return m + n;
+  function add(n) {
+    return function(m) {
+      return m + n;
+    };
   }
-  int.add = def('add', {}, [Int, Int, Int], add);
+  _.add = {
+    types: [Int, Int, Int],
+    impl: add
+  };
 
   //# sub :: Int -> Int -> Int
   //.
-  //. Returns the result of subtracting its second argument from its first
+  //. Returns the result of subtracting its first argument from its second
   //. argument.
   //.
   //. ```javascript
-  //. > sub(1, 2)
-  //. -1
+  //. > sub (1) (100)
+  //. 99
   //. ```
-  function sub(m, n) {
-    return m - n;
+  function sub(n) {
+    return function(m) {
+      return m - n;
+    };
   }
-  int.sub = def('sub', {}, [Int, Int, Int], sub);
+  _.sub = {
+    types: [Int, Int, Int],
+    impl: sub
+  };
 
   //# mul :: Int -> Int -> Int
   //.
   //. Returns the product of its two arguments.
   //.
   //. ```javascript
-  //. > mul(6, 7)
+  //. > mul (6) (7)
   //. 42
   //. ```
-  function mul(m, n) {
-    return m * n;
+  function mul(n) {
+    return function(m) {
+      return m * n;
+    };
   }
-  int.mul = def('mul', {}, [Int, Int, Int], mul);
+  _.mul = {
+    types: [Int, Int, Int],
+    impl: mul
+  };
 
-  //# quot :: Int -> NonZeroInt -> Int
+  //# quot :: NonZeroInt -> Int -> Int
   //.
-  //. Returns the result of dividing its first argument by its second
+  //. Returns the result of dividing its second argument by its first
   //. argument, truncating towards zero.
   //.
   //. Throws if the divisor is zero.
@@ -102,54 +108,64 @@
   //. See also [`div`](#div).
   //.
   //. ```javascript
-  //. > quot(42, 5)
+  //. > quot (5) (42)
   //. 8
   //.
-  //. > quot(42, -5)
+  //. > quot (-5) (42)
   //. -8
   //.
-  //. > quot(-42, 5)
+  //. > quot (5) (-42)
   //. -8
   //.
-  //. > quot(-42, -5)
+  //. > quot (-5) (-42)
   //. 8
   //. ```
-  function quot(m, n) {
-    return (m / n) | 0;
+  function quot(n) {
+    return function(m) {
+      return (m / n) | 0;
+    };
   }
-  int.quot = def('quot', {}, [Int, NonZeroInt, Int], quot);
+  _.quot = {
+    types: [NonZeroInt, Int, Int],
+    impl: quot
+  };
 
-  //# rem :: Int -> NonZeroInt -> Int
+  //# rem :: NonZeroInt -> Int -> Int
   //.
   //. Integer remainder, satisfying:
   //.
-  //.     quot(x, y) * y + rem(x, y) === x
+  //.     quot (y) (x) * y + rem (y) (x) === x
   //.
   //. Throws if the divisor is zero.
   //.
   //. See also [`mod`](#mod).
   //.
   //. ```javascript
-  //. > rem(42, 5)
+  //. > rem (5) (42)
   //. 2
   //.
-  //. > rem(42, -5)
+  //. > rem (-5) (42)
   //. 2
   //.
-  //. > rem(-42, 5)
+  //. > rem (5) (-42)
   //. -2
   //.
-  //. > rem(-42, -5)
+  //. > rem (-5) (-42)
   //. -2
   //. ```
-  function rem(m, n) {
-    return m % n;
+  function rem(n) {
+    return function(m) {
+      return m % n;
+    };
   }
-  int.rem = def('rem', {}, [Int, NonZeroInt, Int], rem);
+  _.rem = {
+    types: [NonZeroInt, Int, Int],
+    impl: rem
+  };
 
-  //# div :: Int -> NonZeroInt -> Int
+  //# div :: NonZeroInt -> Int -> Int
   //.
-  //. Returns the result of dividing its first argument by its second
+  //. Returns the result of dividing its second argument by its first
   //. argument, truncating towards negative infinity.
   //.
   //. Throws if the divisor is zero.
@@ -157,50 +173,60 @@
   //. See also [`quot`](#quot).
   //.
   //. ```javascript
-  //. > div(42, 5)
+  //. > div (5) (42)
   //. 8
   //.
-  //. > div(42, -5)
+  //. > div (-5) (42)
   //. -9
   //.
-  //. > div(-42, 5)
+  //. > div (5) (-42)
   //. -9
   //.
-  //. > div(-42, -5)
+  //. > div (-5) (-42)
   //. 8
   //. ```
-  function div(m, n) {
-    return Math.floor(m / n);
+  function div(n) {
+    return function(m) {
+      return Math.floor (m / n);
+    };
   }
-  int.div = def('div', {}, [Int, NonZeroInt, Int], div);
+  _.div = {
+    types: [NonZeroInt, Int, Int],
+    impl: div
+  };
 
-  //# mod :: Int -> NonZeroInt -> Int
+  //# mod :: NonZeroInt -> Int -> Int
   //.
   //. Integer modulus, satisfying:
   //.
-  //.     div(x, y) * y + mod(x, y) === x
+  //.     div (y) (x) * y + mod (y) (x) === x
   //.
   //. Throws if the divisor is zero.
   //.
   //. See also [`rem`](#rem).
   //.
   //. ```javascript
-  //. > mod(42, 5)
+  //. > mod (5) (42)
   //. 2
   //.
-  //. > mod(42, -5)
+  //. > mod (-5) (42)
   //. -3
   //.
-  //. > mod(-42, 5)
+  //. > mod (5) (-42)
   //. 3
   //.
-  //. > mod(-42, -5)
+  //. > mod (-5) (-42)
   //. -2
   //. ```
-  function mod(m, n) {
-    return (m % n + n) % n;
+  function mod(n) {
+    return function(m) {
+      return (m % n + n) % n;
+    };
   }
-  int.mod = def('mod', {}, [Int, NonZeroInt, Int], mod);
+  _.mod = {
+    types: [NonZeroInt, Int, Int],
+    impl: mod
+  };
 
   //# and :: Int -> Int -> Int
   //.
@@ -208,13 +234,18 @@
   //. which both arguments have a one.
   //.
   //. ```javascript
-  //. > and(parseInt('1100', 2), parseInt('1010', 2))
-  //. 8
+  //. > and (0b1100) (0b1010)
+  //. 0b1000
   //. ```
-  function and(m, n) {
-    return m & n;
+  function and(n) {
+    return function(m) {
+      return m & n;
+    };
   }
-  int.and = def('and', {}, [Int, Int, Int], and);
+  _.and = {
+    types: [Int, Int, Int],
+    impl: and
+  };
 
   //# or :: Int -> Int -> Int
   //.
@@ -222,13 +253,18 @@
   //. which at least one argument has a one.
   //.
   //. ```javascript
-  //. > or(parseInt('1100', 2), parseInt('1010', 2))
-  //. 14
+  //. > or (0b1100) (0b1010)
+  //. 0b1110
   //. ```
-  function or(m, n) {
-    return m | n;
+  function or(n) {
+    return function(m) {
+      return m | n;
+    };
   }
-  int.or = def('or', {}, [Int, Int, Int], or);
+  _.or = {
+    types: [Int, Int, Int],
+    impl: or
+  };
 
   //# xor :: Int -> Int -> Int
   //.
@@ -236,56 +272,75 @@
   //. which exactly one argument has a one.
   //.
   //. ```javascript
-  //. > xor(parseInt('1100', 2), parseInt('1010', 2))
-  //. 6
+  //. > xor (0b1100) (0b1010)
+  //. 0b0110
   //. ```
-  function xor(m, n) {
-    return m ^ n;
+  function xor(n) {
+    return function(m) {
+      return m ^ n;
+    };
   }
-  int.xor = def('xor', {}, [Int, Int, Int], xor);
+  _.xor = {
+    types: [Int, Int, Int],
+    impl: xor
+  };
 
   //# not :: Int -> Int
   //.
   //. [Bitwise NOT][~], satisfying:
   //.
-  //.     not(x) === -(x + 1)
+  //.     not (x) === -(x + 1)
   //.
   //. ```javascript
-  //. > not(42)
+  //. > not (42)
   //. -43
   //. ```
   function not(n) {
     return ~n;
   }
-  int.not = def('not', {}, [Int, Int], not);
+  _.not = {
+    types: [Int, Int],
+    impl: not
+  };
 
   //# even :: Int -> Boolean
   //.
   //. Returns `true` if its argument is even; `false` if it is odd.
   //.
   //. ```javascript
-  //. > even(42)
+  //. > even (42)
   //. true
   //. ```
   function even(n) {
     return n % 2 === 0;
   }
-  int.even = def('even', {}, [Int, $.Boolean], even);
+  _.even = {
+    types: [Int, $.Boolean],
+    impl: even
+  };
 
   //# odd :: Int -> Boolean
   //.
   //. Returns `true` if its argument is odd; `false` if it is even.
   //.
   //. ```javascript
-  //. > odd(42)
+  //. > odd (42)
   //. false
   //. ```
   function odd(n) {
     return n % 2 !== 0;
   }
-  int.odd = def('odd', {}, [Int, $.Boolean], odd);
+  _.odd = {
+    types: [Int, $.Boolean],
+    impl: odd
+  };
 
-  return int;
+  var env = $.env.concat ([Int, NonZeroInt]);
+  var def = $.create ({checkTypes: true, env: env});
+  return (Object.keys (_)).reduce (function(int, name) {
+    int[name] = def (name) ({}) (_[name].types) (_[name].impl);
+    return int;
+  }, {Int: Int, NonZeroInt: NonZeroInt});
 
 }));
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "npm run lint && sanctuary-test && npm run doctest"
   },
   "dependencies": {
-    "sanctuary-def": "0.14.x"
+    "sanctuary-def": "0.15.x"
   },
   "devDependencies": {
     "jsverify": "0.7.x",

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var assert = require('assert');
+var assert = require ('assert');
 
-var jsc = require('jsverify');
-var $ = require('sanctuary-def');
-var Z = require('sanctuary-type-classes');
+var jsc = require ('jsverify');
+var $ = require ('sanctuary-def');
+var Z = require ('sanctuary-type-classes');
 
-var int = require('..');
+var int = require ('..');
 
 
 var Int = int.Int;
@@ -25,392 +25,377 @@ var not = int.not;
 var even = int.even;
 var odd = int.odd;
 
-function eq(actual, expected) {
-  assert.strictEqual(arguments.length, eq.length);
-  assert.strictEqual(Z.toString(actual), Z.toString(expected));
-  assert.strictEqual(Z.equals(actual, expected), true);
+//    eq :: a -> b -> Undefined !
+function eq(actual) {
+  assert.strictEqual (arguments.length, eq.length);
+  return function eq$1(expected) {
+    assert.strictEqual (arguments.length, eq$1.length);
+    assert.strictEqual (Z.toString (actual), Z.toString (expected));
+    assert.strictEqual (Z.equals (actual, expected), true);
+  };
 }
-
-//  binary :: String -> Number
-function binary(s) { return parseInt(s, 2); }
 
 //  isInt :: Any -> Boolean
-function isInt(x) {
-  return $.test($.env, Int, x);
-}
+var isInt = $.test ($.env) (Int);
 
 //  isNonZeroInt :: Any -> Boolean
-function isNonZeroInt(x) {
-  return $.test($.env, NonZeroInt, x);
-}
+var isNonZeroInt = $.test ($.env) (NonZeroInt);
 
 //  maxInt :: Int
-var maxInt = Math.pow(2, 31) - 1;
+var maxInt = Math.pow (2, 31) - 1;
 
 //  minInt :: Int
-var minInt = -Math.pow(2, 31);
+var minInt = -Math.pow (2, 31);
 
 
-suite('Int', function() {
+suite ('Int', function() {
 
-  test('is a nullary type', function() {
-    eq(Int.name, 'sanctuary-int/Int');
-    eq(Int.url, 'https://github.com/sanctuary-js/sanctuary-int#Int');
-    eq(Int.toString(), 'Int');
+  test ('is a nullary type', function() {
+    eq (Int.name) ('sanctuary-int/Int');
+    eq (Int.url) ('https://github.com/sanctuary-js/sanctuary-int#Int');
+    eq (Int.toString ()) ('Int');
   });
 
-  test('represents integers in the range [-2^31 .. 2^31)', function() {
-    eq(isInt(0), true);
-    eq(isInt(1), true);
-    eq(isInt(-0), true);
-    eq(isInt(-1), true);
-    eq(isInt(maxInt), true);
-    eq(isInt(minInt), true);
+  test ('represents integers in the range [-2^31 .. 2^31)', function() {
+    eq (isInt (0)) (true);
+    eq (isInt (1)) (true);
+    eq (isInt (-0)) (true);
+    eq (isInt (-1)) (true);
+    eq (isInt (maxInt)) (true);
+    eq (isInt (minInt)) (true);
 
-    eq(isInt('42'), false);
-    eq(isInt(12.34), false);
-    eq(isInt(maxInt + 1), false);
-    eq(isInt(minInt - 1), false);
-    eq(isInt(Infinity), false);
-    eq(isInt(-Infinity), false);
-    eq(isInt(NaN), false);
-    eq(isInt(new Number(0)), false);
-  });
-
-});
-
-suite('NonZeroInt', function() {
-
-  test('is a nullary type', function() {
-    eq(NonZeroInt.name, 'sanctuary-int/NonZeroInt');
-    eq(NonZeroInt.url, 'https://github.com/sanctuary-js/sanctuary-int#NonZeroInt');
-    eq(NonZeroInt.toString(), 'NonZeroInt');
-  });
-
-  test('represents non-zero integers in the range [-2^31 .. 2^31)', function() {
-    eq(isNonZeroInt(0), false);
-    eq(isNonZeroInt(1), true);
-    eq(isNonZeroInt(-0), false);
-    eq(isNonZeroInt(-1), true);
-    eq(isNonZeroInt(maxInt), true);
-    eq(isNonZeroInt(minInt), true);
-
-    eq(isNonZeroInt('42'), false);
-    eq(isNonZeroInt(12.34), false);
-    eq(isNonZeroInt(maxInt + 1), false);
-    eq(isNonZeroInt(minInt - 1), false);
-    eq(isNonZeroInt(Infinity), false);
-    eq(isNonZeroInt(-Infinity), false);
-    eq(isNonZeroInt(NaN), false);
-    eq(isNonZeroInt(new Number(0)), false);
-    eq(isNonZeroInt(new Number(1)), false);
+    eq (isInt ('42')) (false);
+    eq (isInt (12.34)) (false);
+    eq (isInt (maxInt + 1)) (false);
+    eq (isInt (minInt - 1)) (false);
+    eq (isInt (Infinity)) (false);
+    eq (isInt (-Infinity)) (false);
+    eq (isInt (NaN)) (false);
+    eq (isInt (new Number (0))) (false);
   });
 
 });
 
-suite('add', function() {
+suite ('NonZeroInt', function() {
 
-  test('is a binary function', function() {
-    eq(typeof add, 'function');
-    eq(add.length, 2);
-    eq(add.toString(), 'add :: Int -> Int -> Int');
+  test ('is a nullary type', function() {
+    eq (NonZeroInt.name) ('sanctuary-int/NonZeroInt');
+    eq (NonZeroInt.url) ('https://github.com/sanctuary-js/sanctuary-int#NonZeroInt');
+    eq (NonZeroInt.toString ()) ('NonZeroInt');
   });
 
-  test('returns the sum', function() {
-    eq(add(1, 2), 3);
+  test ('represents non-zero integers in the range [-2^31 .. 2^31)', function() {
+    eq (isNonZeroInt (0)) (false);
+    eq (isNonZeroInt (1)) (true);
+    eq (isNonZeroInt (-0)) (false);
+    eq (isNonZeroInt (-1)) (true);
+    eq (isNonZeroInt (maxInt)) (true);
+    eq (isNonZeroInt (minInt)) (true);
+
+    eq (isNonZeroInt ('42')) (false);
+    eq (isNonZeroInt (12.34)) (false);
+    eq (isNonZeroInt (maxInt + 1)) (false);
+    eq (isNonZeroInt (minInt - 1)) (false);
+    eq (isNonZeroInt (Infinity)) (false);
+    eq (isNonZeroInt (-Infinity)) (false);
+    eq (isNonZeroInt (NaN)) (false);
+    eq (isNonZeroInt (new Number (0))) (false);
+    eq (isNonZeroInt (new Number (1))) (false);
   });
 
-  test('has identity element (zero)', function() {
-    jsc.assert(jsc.forall(jsc.int32, function(x) {
-      return Z.equals(add(x, 0), x) &&
-             Z.equals(add(0, x), x);
+});
+
+suite ('add', function() {
+
+  test ('is a binary function', function() {
+    eq (typeof add) ('function');
+    eq (add.length) (1);
+    eq (add.toString ()) ('add :: Int -> Int -> Int');
+  });
+
+  test ('returns the sum', function() {
+    eq (add (1) (2)) (3);
+  });
+
+  test ('has identity element (zero)', function() {
+    jsc.assert (jsc.forall (jsc.int32, function(x) {
+      return Z.equals (add (x) (0), x) &&
+             Z.equals (add (0) (x), x);
     }));
   });
 
-  test('is commutative', function() {
-    jsc.assert(jsc.forall(jsc.int32, jsc.int32, function(x, y) {
-      // The sum may be outside the valid range.
-      return !isInt(x + y) ||
-             Z.equals(add(x, y),
-                      add(y, x));
+  test ('is commutative', function() {
+    jsc.assert (jsc.forall (jsc.int16, jsc.int16, function(x, y) {
+      return Z.equals (add (x) (y),
+                       add (y) (x));
     }));
   });
 
-  test('is associative', function() {
-    jsc.assert(jsc.forall(jsc.int32, jsc.int32, jsc.int32, function(x, y, z) {
-      // The sum may be outside the valid range.
-      return !isInt(x + y) ||
-             !isInt(y + z) ||
-             !isInt(x + y + z) ||
-             Z.equals(add(add(x, y), z),
-                      add(x, add(y, z)));
+  test ('is associative', function() {
+    jsc.assert (jsc.forall (jsc.int16, jsc.int16, jsc.int16, function(x, y, z) {
+      return Z.equals (add (add (x) (y)) (z),
+                       add (x) (add (y) (z)));
     }));
   });
 
 });
 
-suite('sub', function() {
+suite ('sub', function() {
 
-  test('is a binary function', function() {
-    eq(typeof sub, 'function');
-    eq(sub.length, 2);
-    eq(sub.toString(), 'sub :: Int -> Int -> Int');
+  test ('is a binary function', function() {
+    eq (typeof sub) ('function');
+    eq (sub.length) (1);
+    eq (sub.toString ()) ('sub :: Int -> Int -> Int');
   });
 
-  test('returns the difference', function() {
-    eq(sub(1, 2), -1);
+  test ('returns the difference', function() {
+    eq (sub (2) (1)) (-1);
   });
 
-  test('has right identity element (zero)', function() {
-    jsc.assert(jsc.forall(jsc.int32, function(x) {
-      return Z.equals(sub(x, 0), x) &&
-             Z.equals(sub(x, x), 0);
+  test ('has right identity element (zero)', function() {
+    jsc.assert (jsc.forall (jsc.int32, function(x) {
+      return Z.equals (sub (0) (x), x) &&
+             Z.equals (sub (x) (x), 0);
     }));
   });
 
 });
 
-suite('mul', function() {
+suite ('mul', function() {
 
-  test('is a binary function', function() {
-    eq(typeof mul, 'function');
-    eq(mul.length, 2);
-    eq(mul.toString(), 'mul :: Int -> Int -> Int');
+  test ('is a binary function', function() {
+    eq (typeof mul) ('function');
+    eq (mul.length) (1);
+    eq (mul.toString ()) ('mul :: Int -> Int -> Int');
   });
 
-  test('returns the product', function() {
-    eq(mul(6, 7), 42);
+  test ('returns the product', function() {
+    eq (mul (6) (7)) (42);
   });
 
-  test('has identity element (one)', function() {
-    jsc.assert(jsc.forall(jsc.int32, function(x) {
-      return Z.equals(mul(x, 1), x) &&
-             Z.equals(mul(1, x), x);
+  test ('has identity element (one)', function() {
+    jsc.assert (jsc.forall (jsc.int32, function(x) {
+      return Z.equals (mul (x) (1), x) &&
+             Z.equals (mul (1) (x), x);
     }));
   });
 
-  test('is commutative', function() {
-    jsc.assert(jsc.forall(jsc.int32, jsc.int32, function(x, y) {
-      // The product may be outside the valid range.
-      return !isInt(x * y) ||
-             Z.equals(mul(x, y),
-                      mul(y, x));
+  test ('is commutative', function() {
+    jsc.assert (jsc.forall (jsc.int16, jsc.int16, function(x, y) {
+      return Z.equals (mul (x) (y),
+                       mul (y) (x));
     }));
   });
 
-  test('is associative', function() {
-    jsc.assert(jsc.forall(jsc.int32, jsc.int32, jsc.int32, function(x, y, z) {
-      // The product may be outside the valid range.
-      return !isInt(x * y) ||
-             !isInt(y * z) ||
-             !isInt(x * y * z) ||
-             Z.equals(mul(mul(x, y), z),
-                      mul(x, mul(y, z)));
+  test ('is associative', function() {
+    jsc.assert (jsc.forall (jsc.int8, jsc.int8, jsc.int8, function(x, y, z) {
+      return Z.equals (mul (mul (x) (y)) (z),
+                       mul (x) (mul (y) (z)));
     }));
   });
 
 });
 
-suite('quot', function() {
+suite ('quot', function() {
 
-  test('is a binary function', function() {
-    eq(typeof quot, 'function');
-    eq(quot.length, 2);
-    eq(quot.toString(), 'quot :: Int -> NonZeroInt -> Int');
+  test ('is a binary function', function() {
+    eq (typeof quot) ('function');
+    eq (quot.length) (1);
+    eq (quot.toString ()) ('quot :: NonZeroInt -> Int -> Int');
   });
 
-  test('performs integer division truncated towards 0', function() {
-    eq(quot(42, 5), 8);
-    eq(quot(42, -5), -8);
-    eq(quot(-42, 5), -8);
-    eq(quot(-42, -5), 8);
-  });
-
-});
-
-suite('rem', function() {
-
-  test('is a binary function', function() {
-    eq(typeof rem, 'function');
-    eq(rem.length, 2);
-    eq(rem.toString(), 'rem :: Int -> NonZeroInt -> Int');
-  });
-
-  test('returns the remainder', function() {
-    eq(rem(42, 5), 2);
-    eq(rem(42, -5), 2);
-    eq(rem(-42, 5), -2);
-    eq(rem(-42, -5), -2);
+  test ('performs integer division truncated towards 0', function() {
+    eq (quot (5) (42)) (8);
+    eq (quot (-5) (42)) (-8);
+    eq (quot (5) (-42)) (-8);
+    eq (quot (-5) (-42)) (8);
   });
 
 });
 
-suite('div', function() {
+suite ('rem', function() {
 
-  test('is a binary function', function() {
-    eq(typeof div, 'function');
-    eq(div.length, 2);
-    eq(div.toString(), 'div :: Int -> NonZeroInt -> Int');
+  test ('is a binary function', function() {
+    eq (typeof rem) ('function');
+    eq (rem.length) (1);
+    eq (rem.toString ()) ('rem :: NonZeroInt -> Int -> Int');
   });
 
-  test('performs integer division truncated towards -Infinity', function() {
-    eq(div(7, 2), 3);
-    eq(div(7, -2), -4);
-    eq(div(-7, 2), -4);
-    eq(div(-7, -2), 3);
-    eq(div(0, 1), 0);
-    eq(div(-0, 1), -0);
-  });
-
-});
-
-suite('mod', function() {
-
-  test('is a binary function', function() {
-    eq(typeof mod, 'function');
-    eq(mod.length, 2);
-    eq(mod.toString(), 'mod :: Int -> NonZeroInt -> Int');
-  });
-
-  test('returns the modulus', function() {
-    eq(mod(42, 5), 2);
-    eq(mod(42, -5), -3);
-    eq(mod(-42, 5), 3);
-    eq(mod(-42, -5), -2);
+  test ('returns the remainder', function() {
+    eq (rem (5) (42)) (2);
+    eq (rem (-5) (42)) (2);
+    eq (rem (5) (-42)) (-2);
+    eq (rem (-5) (-42)) (-2);
   });
 
 });
 
-suite('and', function() {
+suite ('div', function() {
 
-  test('is a binary function', function() {
-    eq(typeof and, 'function');
-    eq(and.length, 2);
-    eq(and.toString(), 'and :: Int -> Int -> Int');
+  test ('is a binary function', function() {
+    eq (typeof div) ('function');
+    eq (div.length) (1);
+    eq (div.toString ()) ('div :: NonZeroInt -> Int -> Int');
   });
 
-  test('returns the bitwise AND of its arguments', function() {
-    eq(and(binary('1100'), binary('1010')), binary('1000'));
-  });
-
-});
-
-suite('or', function() {
-
-  test('is a binary function', function() {
-    eq(typeof or, 'function');
-    eq(or.length, 2);
-    eq(or.toString(), 'or :: Int -> Int -> Int');
-  });
-
-  test('returns the bitwise OR of its arguments', function() {
-    eq(or(binary('1100'), binary('1010')), binary('1110'));
+  test ('performs integer division truncated towards -Infinity', function() {
+    eq (div (2) (7)) (3);
+    eq (div (-2) (7)) (-4);
+    eq (div (2) (-7)) (-4);
+    eq (div (-2) (-7)) (3);
+    eq (div (1) (0)) (0);
+    eq (div (1) (-0)) (-0);
   });
 
 });
 
-suite('xor', function() {
+suite ('mod', function() {
 
-  test('is a binary function', function() {
-    eq(typeof xor, 'function');
-    eq(xor.length, 2);
-    eq(xor.toString(), 'xor :: Int -> Int -> Int');
+  test ('is a binary function', function() {
+    eq (typeof mod) ('function');
+    eq (mod.length) (1);
+    eq (mod.toString ()) ('mod :: NonZeroInt -> Int -> Int');
   });
 
-  test('returns the bitwise XOR of its arguments', function() {
-    eq(xor(binary('1100'), binary('1010')), binary('0110'));
-  });
-
-});
-
-suite('not', function() {
-
-  test('is a unary function', function() {
-    eq(typeof not, 'function');
-    eq(not.length, 1);
-    eq(not.toString(), 'not :: Int -> Int');
-  });
-
-  test('returns bitwise NOT of its argument', function() {
-    eq(not(42), ~42);
-    eq(not(42), -43);
-    eq(not(-1), ~-1);
-    eq(not(-1), 0);
+  test ('returns the modulus', function() {
+    eq (mod (5) (42)) (2);
+    eq (mod (-5) (42)) (-3);
+    eq (mod (5) (-42)) (3);
+    eq (mod (-5) (-42)) (-2);
   });
 
 });
 
-suite('even', function() {
+suite ('and', function() {
 
-  test('is a unary function', function() {
-    eq(typeof even, 'function');
-    eq(even.length, 1);
-    eq(even.toString(), 'even :: Int -> Boolean');
+  test ('is a binary function', function() {
+    eq (typeof and) ('function');
+    eq (and.length) (1);
+    eq (and.toString ()) ('and :: Int -> Int -> Int');
   });
 
-  test('returns true if applied to an even integer', function() {
-    eq(even(0), true);
-    eq(even(-0), true);
-    eq(even(2), true);
-    eq(even(-2), true);
-    eq(even(2147483646), true);
-    eq(even(-2147483648), true);
-  });
-
-  test('returns false if applied to an odd integer', function() {
-    eq(even(1), false);
-    eq(even(-1), false);
-    eq(even(2147483647), false);
-    eq(even(-2147483647), false);
+  test ('returns the bitwise AND of its arguments', function() {
+    eq (and (0b1100) (0b1010)) (0b1000);
   });
 
 });
 
-suite('odd', function() {
+suite ('or', function() {
 
-  test('is a unary function', function() {
-    eq(typeof odd, 'function');
-    eq(odd.length, 1);
-    eq(odd.toString(), 'odd :: Int -> Boolean');
+  test ('is a binary function', function() {
+    eq (typeof or) ('function');
+    eq (or.length) (1);
+    eq (or.toString ()) ('or :: Int -> Int -> Int');
   });
 
-  test('returns true if applied to an odd value', function() {
-    eq(odd(1), true);
-    eq(odd(-1), true);
-    eq(odd(2147483647), true);
-    eq(odd(-2147483647), true);
-  });
-
-  test('returns false if applied to an even value', function() {
-    eq(odd(0), false);
-    eq(odd(-0), false);
-    eq(odd(2), false);
-    eq(odd(-2), false);
-    eq(odd(2147483646), false);
-    eq(odd(-2147483648), false);
+  test ('returns the bitwise OR of its arguments', function() {
+    eq (or (0b1100) (0b1010)) ((0b1110));
   });
 
 });
 
-suite('invariants', function() {
+suite ('xor', function() {
 
-  test('quot(x, y) * y + rem(x, y) === x', function() {
-    jsc.assert(jsc.forall(jsc.int32, jsc.int32, function(x, y) {
+  test ('is a binary function', function() {
+    eq (typeof xor) ('function');
+    eq (xor.length) (1);
+    eq (xor.toString ()) ('xor :: Int -> Int -> Int');
+  });
+
+  test ('returns the bitwise XOR of its arguments', function() {
+    eq (xor (0b1100) (0b1010)) ((0b0110));
+  });
+
+});
+
+suite ('not', function() {
+
+  test ('is a unary function', function() {
+    eq (typeof not) ('function');
+    eq (not.length) (1);
+    eq (not.toString ()) ('not :: Int -> Int');
+  });
+
+  test ('returns bitwise NOT of its argument', function() {
+    eq (not (42)) (~42);
+    eq (not (42)) (-43);
+    eq (not (-1)) (~-1);
+    eq (not (-1)) (0);
+  });
+
+});
+
+suite ('even', function() {
+
+  test ('is a unary function', function() {
+    eq (typeof even) ('function');
+    eq (even.length) (1);
+    eq (even.toString ()) ('even :: Int -> Boolean');
+  });
+
+  test ('returns true if applied to an even integer', function() {
+    eq (even (0)) (true);
+    eq (even (-0)) (true);
+    eq (even (2)) (true);
+    eq (even (-2)) (true);
+    eq (even (2147483646)) (true);
+    eq (even (-2147483648)) (true);
+  });
+
+  test ('returns false if applied to an odd integer', function() {
+    eq (even (1)) (false);
+    eq (even (-1)) (false);
+    eq (even (2147483647)) (false);
+    eq (even (-2147483647)) (false);
+  });
+
+});
+
+suite ('odd', function() {
+
+  test ('is a unary function', function() {
+    eq (typeof odd) ('function');
+    eq (odd.length) (1);
+    eq (odd.toString ()) ('odd :: Int -> Boolean');
+  });
+
+  test ('returns true if applied to an odd value', function() {
+    eq (odd (1)) (true);
+    eq (odd (-1)) (true);
+    eq (odd (2147483647)) (true);
+    eq (odd (-2147483647)) (true);
+  });
+
+  test ('returns false if applied to an even value', function() {
+    eq (odd (0)) (false);
+    eq (odd (-0)) (false);
+    eq (odd (2)) (false);
+    eq (odd (-2)) (false);
+    eq (odd (2147483646)) (false);
+    eq (odd (-2147483648)) (false);
+  });
+
+});
+
+suite ('invariants', function() {
+
+  test ('quot (y) (x) * y + rem (y) (x) === x', function() {
+    jsc.assert (jsc.forall (jsc.int32, jsc.int32, function(x, y) {
       return y === 0 ||
-             Z.equals(quot(x, y) * y + rem(x, y), x);
+             Z.equals (quot (y) (x) * y + rem (y) (x), x);
     }));
   });
 
-  test('div(x, y) * y + mod(x, y) === x', function() {
-    jsc.assert(jsc.forall(jsc.int32, jsc.int32, function(x, y) {
+  test ('div (y) (x) * y + mod (y) (x) === x', function() {
+    jsc.assert (jsc.forall (jsc.int32, jsc.int32, function(x, y) {
       return y === 0 ||
-             Z.equals(div(x, y) * y + mod(x, y), x);
+             Z.equals (div (y) (x) * y + mod (y) (x), x);
     }));
   });
 
-  test('not(x) === -(x + 1)', function() {
-    jsc.assert(jsc.forall(jsc.int32, function(x) {
-      return Z.equals(not(x), -(x + 1));
+  test ('not (x) === -(x + 1)', function() {
+    jsc.assert (jsc.forall (jsc.int32, function(x) {
+      return Z.equals (not (x), -(x + 1));
     }));
   });
 


### PR DESCRIPTION
<https://github.com/sanctuary-js/sanctuary-def/releases/tag/v0.15.0>

`def` now produces functions which are strictly curried. This pull request flips the parameters of the various binary functions to make these functions maximally useful in this new strictly curried world. For example, one would now write `int.div (5) (42)` to divide 42 by 5 whereas previously one would have written `int.div(42, 5)`.
